### PR TITLE
Move header/footer toggle to +page.js

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -12,13 +12,11 @@ Use it for headers, footers, and navigation that appear on all pages.
   import SiteHeader from '$lib/components/SiteHeader.svelte';
   import SiteFooter from '$lib/components/SiteFooter.svelte';
 
+  // Access page-level settings (from +page.js)
+  import { page } from '$app/state';
+
   // In Svelte 5, we use $props() to receive the page content
   let { children } = $props();
-
-  // Set to false to hide the NYCity News Service header
-  let showHeader = true;
-  // Set to false to hide the site footer
-  let showFooter = true;
 
   // Navigation links for the header (matching real NYCity News Service)
   const navLinks = [
@@ -34,7 +32,7 @@ Use it for headers, footers, and navigation that appear on all pages.
   ];
 </script>
 
-{#if showHeader}
+{#if page.data.showHeader !== false}
   <SiteHeader {navLinks} />
 {/if}
 
@@ -43,7 +41,7 @@ Use it for headers, footers, and navigation that appear on all pages.
   {@render children()}
 </main>
 
-{#if showFooter}
+{#if page.data.showFooter !== false}
   <SiteFooter />
 {/if}
 

--- a/src/routes/+page.js
+++ b/src/routes/+page.js
@@ -1,0 +1,10 @@
+// Page settings
+// These values are passed to the layout to control what appears on the page.
+export function load() {
+  return {
+    // Set to false to hide the NYCity News Service header
+    showHeader: true,
+    // Set to false to hide the site footer
+    showFooter: true,
+  };
+}


### PR DESCRIPTION
## Summary
- Moves `showHeader`/`showFooter` controls from `+layout.svelte` local variables into a `+page.js` load function
- Layout reads page-level settings via `page.data` from `$app/state`
- Students configure header/footer visibility in `+page.js` alongside their page content

## Test plan
- [ ] `npm run build` passes
- [ ] Set `showHeader: false` in `+page.js` and verify header disappears
- [ ] Set `showFooter: false` in `+page.js` and verify footer disappears
- [ ] Confirm default behavior (both true) still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)